### PR TITLE
added ingress blocks

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -27,21 +27,70 @@ resource "aws_security_group" "allow_user_to_connect" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  ingress {
-    description = "port 80 allow"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
-    description = "port 443 allow"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+    # Inbound rules
+    ingress {
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow SSH access"
+    }
+    ingress {
+        from_port = 80
+        to_port = 80
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow HTTP access"
+    }
+    ingress {
+        from_port = 3000
+        to_port = 32767
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow all traffic on ports 3000-32767"
+    }
+    ingress {
+        from_port = 6379
+        to_port = 6379
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow Redis access"
+    }
+    ingress {
+        from_port = 443
+        to_port = 443
+        protocol = "tcp"    
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow HTTPS access"
+    }
+    ingress {
+        from_port = 465
+        to_port = 465
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow SMTPS access"
+    }
+    ingress {
+        from_port = 3000
+        to_port = 10000
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow traffic on ports 3000-10000"
+    }
+    ingress {
+        from_port = 25
+        to_port = 25
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow SMTP access"
+    }
+    ingress {
+        from_port = 6443
+        to_port = 6443
+        protocol = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+        description = "Allow Kubernetes API access"
+    }
 
   tags = {
     Name = "mysecurity"


### PR DESCRIPTION
Ingress blocks for opening ports.
Edit Inbound rules for security group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded inbound network access to include additional ports for services such as SSH, Redis, SMTP, SMTPS, and Kubernetes API, as well as a broader range of TCP ports.
  - Added descriptive labels for each allowed port to improve clarity in security group rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->