### PR TITLE
Sonar Qube version is no longer supported with current lts-community version

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ sudo usermod -aG docker ubuntu && newgrp docker
 #
 - <b id="Sonar">Install and configure SonarQube (Master machine)</b>
 ```bash
-docker run -itd --name SonarQube-Server -p 9000:9000 sonarqube:lts-community
+docker run -d --name SonarQube-Server -p 9000:9000 sonarqube:community
 ```
 #
 - <b id="Trivy">Install Trivy (Jenkins Worker)</b>


### PR DESCRIPTION
Because lts-community version of sonar is not longer supported now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SonarQube deployment configuration instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->