### PR TITLE
all port add terraform

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -27,6 +27,14 @@ resource "aws_security_group" "allow_user_to_connect" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+egress {
+  description = "Allow outbound TCP traffic on ports 3000-32767"
+  from_port   = 3000
+  to_port     = 32767
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
   ingress {
     description = "port 80 allow"
     from_port   = 80
@@ -42,6 +50,36 @@ resource "aws_security_group" "allow_user_to_connect" {
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+ingress {
+    description = "port 6379 allow"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+ingress {
+    description = "port 465 SMTPS  allow"
+    from_port   = 465
+    to_port     = 465
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+ingress {
+    description = "port range allow"
+    from_port   = 3000
+    to_port     = 10000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+ingress {
+    description = "port 6443 allow"
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
 
   tags = {
     Name = "mysecurity"


### PR DESCRIPTION
add all port ec2.tf  terraform allow open port 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated server network access rules to enable communication on additional service ports (6379, 465, 3000-10000, 6443).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->