### PR TITLE
add: fix jenkins installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,21 @@ sudo usermod -aG docker ubuntu && newgrp docker
 - <b id="Jenkins">Install and configure Jenkins (Master machine)</b>
 ```bash
 sudo apt update -y
-sudo apt install fontconfig openjdk-17-jre -y
+sudo apt install fontconfig openjdk-21-jre -y
 
-sudo wget -O /usr/share/keyrings/jenkins-keyring.asc \
-  https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key
+sudo wget -O /etc/apt/keyrings/jenkins-keyring.asc \
+https://pkg.jenkins.io/debian-stable/jenkins.io-2026.key
   
-echo "deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc]" \
-  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
-  /etc/apt/sources.list.d/jenkins.list > /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/jenkins-keyring.asc] \
+https://pkg.jenkins.io/debian-stable binary/" | sudo tee \
+/etc/apt/sources.list.d/jenkins.list > /dev/null
   
 sudo apt-get update -y
 sudo apt-get install jenkins -y
+
+sudo systemctl start jenkins
+sudo systemctl enable jenkins
+sudo systemctl status jenkins
 ```
 - <b>Now, access Jenkins Master on the browser on port 8080 and configure it</b>.
 #


### PR DESCRIPTION
old jenkins installation have been giving "unable to install jenkins packages" so now this one is latest installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Jenkins installation documentation with Java runtime environment upgrade from openjdk-17-jre to openjdk-21-jre
  * Modified APT package manager keyring paths and updated corresponding source configuration references
  * Added service management commands for starting Jenkins, enabling auto-start functionality, and verifying service status
  * Formatting improvements throughout installation workflow documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->